### PR TITLE
Prevent default scroll after adding coupon and include custom scrolling

### DIFF
--- a/assets/js/src/custom.js
+++ b/assets/js/src/custom.js
@@ -1423,6 +1423,7 @@ botiga.misc = {
 	init: function() {
 		this.wcExpressPayButtons();
 		this.singleProduct();
+		this.cart();
 		this.checkout();
 		this.customizer();
 	},
@@ -1527,6 +1528,30 @@ botiga.misc = {
 			$this.closest( '.variations_form' ).find( '.reset_variations' ).css( 'display', 'none' );
 		} else {
 			$this.closest( '.variations_form' ).find( '.reset_variations' ).css( 'display', 'inline-block' );
+		}
+	},
+	cart: function() {
+		const is_cart_page = document.querySelector( 'body.woocommerce-cart' );
+
+		if ( is_cart_page === null ) {
+			return false;
+		}
+
+		if( typeof jQuery === 'function' ) {
+			(function($){
+				if ( $( 'header.has-sticky-header' ).length ) {
+					$( document ).on( 'updated_cart_totals', function() {
+						$( window ).on( 'scroll', function(e){
+							$( 'html, body' ).stop( true, false );
+							$( this ).off( e );
+							
+							$( 'html, body' ).animate({
+								scrollTop: $( '[role="alert"]' ).offset().top - ( $( 'header.has-sticky-header' ).height() )
+							}, 1000);
+						} );
+					} );
+				}
+			})(jQuery);
 		}
 	},
 	checkout: function() {


### PR DESCRIPTION
This PR removes the default WooCommerce scrolling after adding a coupon in the cart page. Then it is replaced with Botiga custom scrolling taking to account the header height as offset. This happens only whether sticky header is enabled. 