### PR TITLE
Fix botiga core carousel script

### DIFF
--- a/assets/js/src/botiga-carousel.js
+++ b/assets/js/src/botiga-carousel.js
@@ -232,7 +232,9 @@ class Siema {
      * Build a sliderFrame and slide to a current item.
      */
     buildSliderFrame() {
-        if( this.innerElements.length <= this.perPage ) {
+        const has_nav = this.parentSelector.querySelector( '.botiga-carousel-nav-next' ) !== null ? true : false;
+
+        if( has_nav && this.innerElements.length <= this.perPage ) {
             this.parentSelector.querySelector( '.botiga-carousel-nav-next' ).remove();
             this.parentSelector.querySelector( '.botiga-carousel-nav-prev' ).remove();
             return false;

--- a/assets/js/src/custom.js
+++ b/assets/js/src/custom.js
@@ -1303,6 +1303,13 @@ botiga.carousel = {
 					margin = 15;
 				}
 
+				const itemsQty = carouselEl.querySelectorAll( 'li.product' ).length;
+				if ( itemsQty <= parseInt( perPage ) ) {
+					carouselEl.classList.add( 'botiga-carousel-not-initialized' );
+
+					return false;
+				}
+
 				// Initialize
 				var carousel = new Siema({
 					parentSelector: carouselEl,

--- a/assets/sass/components/misc/_carousel.scss
+++ b/assets/sass/components/misc/_carousel.scss
@@ -83,6 +83,13 @@
 }
 
 .botiga-carousel {
+	&.botiga-carousel-not-initialized {
+		.botiga-carousel-stage {
+			opacity: 1;
+			visibility: visible;
+		}
+	}
+
     &.botiga-carousel-nav2 {
         .botiga-carousel-nav-next,
         .botiga-carousel-nav-prev {


### PR DESCRIPTION
- Fixes a JS error regarding navigation buttons returning null.
- Add an improvement to the botiga carousel JS code to don't initialize the carousel when the number of columns to display in the grid is less or equal the quantity of items inside the carousel