### PR TITLE
Single blog posts: The page builder mode, when enabled, isn't following the blocks width settings (e.g full width)

### DIFF
--- a/assets/sass/components/content/_posts-and-pages.scss
+++ b/assets/sass/components/content/_posts-and-pages.scss
@@ -29,6 +29,12 @@
 	}
 }
 
+.single-post {
+	.entry-content {
+		--bt-single-post-entry-content-max-width: 730px;
+	}
+}
+
 .single-post:not(.blog-single-layout2):not(.blog-single-layout3) .no-sidebar,
 .single-post:not(.blog-single-layout2):not(.blog-single-layout3).no-sidebar  {
 	.entry-header,
@@ -38,7 +44,7 @@
 	.post-navigation,
 	.comments-area,
 	.single-post-author {
-		max-width: 730px;
+		max-width: var(--bt-single-post-entry-content-max-width);
 		margin-left: auto;
 		margin-right: auto;
 	}

--- a/functions.php
+++ b/functions.php
@@ -554,6 +554,7 @@ require get_template_directory() . '/inc/classes/class-botiga-posts-archive.php'
 require get_template_directory() . '/inc/classes/class-botiga-svg-icons.php';
 require get_template_directory() . '/inc/classes/class-botiga-metabox.php';
 require get_template_directory() . '/inc/classes/class-botiga-custom-css.php';
+require get_template_directory() . '/inc/classes/class-botiga-backward-compatibility.php';
 
 /**
  * Theme ajax callbacks.

--- a/inc/classes/class-botiga-backward-compatibility.php
+++ b/inc/classes/class-botiga-backward-compatibility.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Class for backward compatibility.
+ * This class is responsible handling dynamic theme stuff based on the first version
+ * which the user started using the theme.
+ * 
+ * E.g Inject certain pieces of CSS only to specific versions from the theme.
+ * 
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Botiga_Backward_Compatibility {
+
+    /**
+     * First theme version.
+     * 
+     * @var string
+     */
+    private $first_theme_version;
+
+    /**
+     * Constructor.
+     * 
+     */
+    public function __construct() {
+        $this->first_theme_version = get_option( 'botiga-first-theme-version' );
+
+        add_action( 'wp_enqueue_scripts', array( $this, 'set_single_blog_posts_container_full_width' ), 20 );
+    }
+
+    /**
+     * Set single blog posts container to full width (with page builder mode enabled).
+     * This should happen only for users who have started using the theme from version 2.2.15.
+     * 
+     * @param string $css
+     * @since 2.2.15
+     * 
+     * @return void
+     */
+    public function set_single_blog_posts_container_full_width() {
+        if ( $this->first_theme_version && version_compare( $this->first_theme_version, '2.2.15', '<' ) ) {
+            return;
+        }
+
+        if ( ! is_singular( 'post' ) ) {
+            return;
+        }
+
+        $page_builder_mode = botiga_get_page_builder_mode();
+        if ( ! $page_builder_mode ) {
+            return;
+        }
+
+        $css = "
+            .single-post .entry-content {
+                --bt-single-post-entry-content-max-width: 100%;
+            }
+        ";
+        
+        wp_add_inline_style( 'botiga-style', $css );
+    }
+}
+
+new Botiga_Backward_Compatibility();

--- a/inc/classes/class-botiga-backward-compatibility.php
+++ b/inc/classes/class-botiga-backward-compatibility.php
@@ -42,7 +42,10 @@ class Botiga_Backward_Compatibility {
      * @return void
      */
     public function set_single_blog_posts_container_full_width() {
-        if ( $this->first_theme_version && version_compare( $this->first_theme_version, '2.2.15', '<' ) ) {
+        if ( 
+            ! $this->first_theme_version || 
+            ( $this->first_theme_version && version_compare( $this->first_theme_version, '2.2.15', '<' ) )
+        ) {
             return;
         }
 

--- a/inc/classes/class-botiga-custom-css.php
+++ b/inc/classes/class-botiga-custom-css.php
@@ -4,8 +4,7 @@
  *
  */
 
-
-if ( !class_exists( 'Botiga_Custom_CSS' ) ) :
+if ( ! class_exists( 'Botiga_Custom_CSS' ) ) :
 
 	/**
 	 * Botiga_Custom_CSS 
@@ -1918,37 +1917,12 @@ if ( !class_exists( 'Botiga_Custom_CSS' ) ) :
 			$css .= $this->get_background_color_rgba_css( 'content_cards_background', '#f5f5f5', 'table.woocommerce-product-attributes tr:nth-child(even)', 0.3 );
 
 			//Buttons
-			// $css .= $this->get_top_bottom_padding_css( 'button_top_bottom_padding', $defaults = array( 'desktop' => 13, 'tablet' => 13, 'mobile' => 13 ), 'button,a.button,.wp-block-button .wp-block-button__link,.wp-block-button__link,.wc-block-components-button,ul.wc-block-grid__products li.wc-block-grid__product .wp-block-button__link,ul.wc-block-grid__products li.wc-block-grid__product .button,ul.products li.product .button,input[type="button"],input[type="reset"],input[type="submit"]' );
-			// $css .= $this->get_left_right_padding_css( 'button_left_right_padding', $defaults = array( 'desktop' => 24, 'tablet' => 24, 'mobile' => 24 ), 'button,a.button,.wp-block-button__link,.wc-block-components-button,ul.wc-block-grid__products li.wc-block-grid__product .wp-block-button__link,ul.wc-block-grid__products li.wc-block-grid__product .button,ul.products li.product .button,input[type="button"],input[type="reset"],input[type="submit"]' );
-			// $css .= $this->get_border_color_css( 'button_border_color', '#212121', "button,a.button,.wp-block-button .wp-block-button__link,.wp-block-button__link,.wc-block-components-button,input[type=\"button\"],input[type=\"reset\"],input[type=\"submit\"]" );
-			// $css .= $this->get_border_color_css( 'button_border_color_hover', '#757575', "button:hover,a.button:hover,.wp-block-button .wp-block-button__link:hover,.wp-block-button__link:hover,.wc-block-components-button:hover,input[type=\"button\"]:hover,input[type=\"reset\"]:hover,input[type=\"submit\"]:hover" );
-
 			$button_text_transform = get_theme_mod( 'button_text_transform', 'uppercase' );
 			$button_text_decoration = get_theme_mod( 'button_text_decoration', 'none' );
 			$css .= "a.button,.button,.wp-block-button__link,.wc-block-components-button,.wc-block-components-button .wc-block-components-button__text,ul.products li.product .button,input[type=\"button\"],input[type=\"reset\"],input[type=\"submit\"] { text-transform:" . esc_attr( $button_text_transform ) . "; text-decoration:" . esc_attr( $button_text_decoration ) . ";}" . "\n";
 
-			// $css .= $this->get_background_color_css( 'button_background_color', '#212121', 'button:not(.has-background),a.button:not(.has-background),.wp-block-button .wp-block-button__link:not(.has-background),.wp-block-button__link:not(.has-background),.wp-block-search .wp-block-search__button:not(.has-background),input[type="button"]:not(.has-background),input[type="reset"]:not(.has-background),input[type="submit"]:not(.has-background),.comments-area .comment-reply-link:not(.has-background),.botiga-sc-product-quantity' );          
-			// $css .= $this->get_background_color_css( 'button_background_color_hover', '#757575', '.is-style-outline .wp-block-button__link:not(.has-background):hover,button:not(.has-background):hover,a.button:not(.has-background):hover,.wp-block-button .wp-block-button__link:not(.has-background):hover,.wp-block-button__link:not(.has-background):hover,.wp-block-search .wp-block-search__button:not(.has-background):hover,input[type="button"]:not(.has-background):hover,input[type="reset"]:not(.has-background):hover,input[type="submit"]:not(.has-background):hover,.comments-area .comment-reply-link:not(.has-background):hover' );       
-
-			// $css .= $this->get_color_css( 'button_color', '#FFF', '.wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),button:not(.has-text-color),a.button:not(.wc-forward):not(.has-text-color),a.button.checkout:not(.has-text-color),.checkout-button.button:not(.has-text-color),.wp-block-button .wp-block-button__link:not(.has-text-color),.wp-block-button__link:not(.has-text-color),input[type="button"]:not(.has-text-color),input[type="reset"]:not(.has-text-color),input[type="submit"]:not(.has-text-color),.woocommerce-message .button.wc-forward:not(.has-text-color),.comments-area .comment-reply-link:not(.has-text-color), .wp-block-search .wp-block-search__button:not(.has-text-color),.botiga-sc-product-quantity' );          
-			// $css .= $this->get_color_css( 'button_color_hover', '#FFF', '.is-style-outline .wp-block-button__link:not(.has-text-color):hover,button:hover,a.button:not(.wc-forward):not(.has-text-color):hover,a.button.checkout:not(.has-text-color):hover,.checkout-button.button:not(.has-text-color):hover,.wp-block-button .wp-block-button__link:not(.has-text-color):hover,.wp-block-button__link:not(.has-text-color):hover,input[type="button"]:not(.has-text-color):hover,input[type="reset"]:not(.has-text-color):hover,input[type="submit"]:not(.has-text-color):hover,.woocommerce-message .button.wc-forward:not(.has-text-color):hover,.comments-area .comment-reply-link:not(.has-text-color):hover, .wp-block-search .wp-block-search__button:not(.has-text-color):hover' );
-			
-			// $css .= $this->get_fill_css( 'button_color', '#FFF', '.woocommerce-product-search .search-submit svg, #masthead-mobile .search-submit svg:not(.stroke-based), ul.wc-block-grid__products li.wc-block-grid__product .wp-block-button__link svg, ul.wc-block-grid__products li.product .wp-block-button__link svg, ul.products li.wc-block-grid__product .wp-block-button__link svg, ul.products li.product .button svg' );
-			// $css .= $this->get_fill_css( 'button_color_hover', '#FFF', '.woocommerce-product-search .search-submit:hover svg, #masthead-mobile .search-submit:hover svg:not(.stroke-based), ul.wc-block-grid__products li.wc-block-grid__product .wp-block-button__link:hover svg, ul.wc-block-grid__products li.product .wp-block-button__link:hover svg, ul.products li.wc-block-grid__product .wp-block-button__link:hover svg, ul.products li.product .button:hover svg' );
-
-			$button_border_color = get_theme_mod( 'button_border_color', '#212121' );
-			$button_border_color_hover = get_theme_mod( 'button_border_color_hover', '#757575' );
-			// $css .= $this->get_border_color_css( 'button_border_color', '#212121', '.wp-block-button.is-style-outline .wp-block-button__link, .wp-block-button__link.is-style-outline,.wp-block-search .wp-block-search__button,button,a.button,.wp-block-button__link,input[type=\"button\"],input[type=\"reset\"],input[type=\"submit\"]' );
-			// $css .= $this->get_border_color_css( 'button_border_color_hover', '#757575', '.wp-block-button.is-style-outline .wp-block-button__link:hover,button:hover,a.button:hover,.wp-block-button__link:hover,.wp-block-search .wp-block-search__button:hover,input[type=\"button\"]:hover,input[type=\"reset\"]:hover,input[type=\"submit\"]:hover' );
-
 			//Widgets
 			$css .= $this->get_border_color_rgba_css( 'color_body_text', '#212121', '.widget-area .widget', 0.1 );
-			// $css .= $this->get_color_css( 'button_color', '', '.widget_product_tag_cloud .tag-cloud-link' );
-			// $css .= $this->get_color_css( 'button_color_hover', '', '.widget_product_tag_cloud .tag-cloud-link:hover' );
-			// $css .= $this->get_background_color_css( 'button_background_color', '', '.widget_product_tag_cloud .tag-cloud-link' );
-			// $css .= $this->get_background_color_css( 'button_background_color_hover', '', '.widget_product_tag_cloud .tag-cloud-link:hover' );
-			// $css .= $this->get_background_color_css( 'button_background_color', '', '.widget_price_filter .ui-slider .ui-slider-handle' );
-			// $css .= $this->get_background_color_css( 'button_background_color_hover', '', '.widget_price_filter .ui-slider .ui-slider-handle:hover' );
 
 			//WPForms
 			if( defined( 'WPFORMS_VERSION' ) ) {

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -11,6 +11,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Get the page builder mode.
+ * 
+ * @return string
+ */
+function botiga_get_page_builder_mode() {
+	global $post;
+
+	if ( empty( $post ) ) {
+		return;
+	}
+
+	$page_builder_mode = get_post_meta( $post->ID, '_botiga_page_builder_mode', true );
+
+	/**
+	 * Hook 'botiga_page_builder_mode'
+	 * Filters the page builder mode.
+	 * 
+	 * @since 2.2.10
+	 */
+	return apply_filters( 'botiga_page_builder_mode', $page_builder_mode, $post );
+}
+
+/**
  * Check if the current page has a WooCommerce shortcode.
  *
  * @param object $post
@@ -135,4 +158,14 @@ function botiga_is_page_loaded_by_builders() {
 	}
 
 	return false;
+}
+
+/**
+ * Get Botiga first theme version.
+ * Returns from the database a string if the first theme version is set, otherwise returns false.
+ * 
+ * @return string|bool
+ */
+function botiga_get_first_theme_version() {
+	return get_option( 'botiga-first-theme-version' ) ? get_option( 'botiga-first-theme-version' ) : false;
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -269,15 +269,7 @@ function botiga_main_wrapper_start() {
 	global $post;
 
 	if ( isset( $post ) ) {
-		$page_builder_mode = get_post_meta( $post->ID, '_botiga_page_builder_mode', true );
-
-		/**
-		 * Hook 'botiga_page_builder_mode'
-		 * Filters the page builder mode.
-		 * 
-		 * @since 2.2.10
-		 */
-		$page_builder_mode = apply_filters( 'botiga_page_builder_mode', $page_builder_mode, $post ); 
+		$page_builder_mode = botiga_get_page_builder_mode(); 
 
 		if ( $page_builder_mode && ! is_singular( 'product' ) ) {
 			echo '<div class="content-wrapper">';
@@ -299,15 +291,7 @@ function botiga_main_wrapper_end() {
 	global $post;
 
 	if ( isset( $post ) ) {
-		$page_builder_mode  = get_post_meta( $post->ID, '_botiga_page_builder_mode', true );
-
-		/**
-		 * Hook 'botiga_page_builder_mode'
-		 * Filters the page builder mode.
-		 * 
-		 * @since 2.2.10
-		 */
-		$page_builder_mode = apply_filters( 'botiga_page_builder_mode', $page_builder_mode, $post );
+		$page_builder_mode = botiga_get_page_builder_mode();
 
 		if ( $page_builder_mode && ! is_singular( 'product' ) ) {
 			echo '</div>';
@@ -335,15 +319,7 @@ function botiga_page_builder_mode() {
 	$first_theme_version = get_option( 'botiga-first-theme-version' );
 
 	if ( isset( $post ) && is_singular() ) {
-		$page_builder_mode  = get_post_meta( $post->ID, '_botiga_page_builder_mode', true );
-
-		/**
-		 * Hook 'botiga_page_builder_mode'
-		 * Filters the page builder mode.
-		 * 
-		 * @since 2.2.10
-		 */
-		$page_builder_mode = apply_filters( 'botiga_page_builder_mode', $page_builder_mode, $post );
+		$page_builder_mode  = botiga_get_page_builder_mode();
 
 		if ( $page_builder_mode ) {
 			add_filter( 'botiga_entry_header', '__return_false' );


### PR DESCRIPTION
This PR includes a new compatibility handler which is able to detect which version the customer started using the theme. Then, we can compare to discover whether it's an old user or new user as well as compare versions. 

So the fix for the single blog posts will, for now, apply only to new users. This is needed to avoid backward compatibility with existing users. 

We should make this change permanent and apply for everyone when the next major version from the theme is released.