### PR TITLE
Fix wishlist for custom shortcode

### DIFF
--- a/inc/plugins/woocommerce/features/product-card.php
+++ b/inc/plugins/woocommerce/features/product-card.php
@@ -237,6 +237,7 @@ function botiga_page_has_woo_shortcode() {
 	$shortcodes = array(
 		'products',
 		'product_page',
+		'latest_arrivals', // third-party shortcode
 	);
 
 	if( $post ) {


### PR DESCRIPTION
The client is using a custom shortcode called ‘latest_arrivals,’ which is causing the wishlist to fail to load. For now, I’ve added the shortcode to the ‘botiga_page_has_woo_shortcode’ function without creating a new one. Please check if this approach is fine or if a separate function is needed for this shortcode.

I’ve also applied this change to the client’s website.